### PR TITLE
Explicitly specified owner for config files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Examples
         openldap_server_domain_name: example.com
         openldap_server_rootpw: passme
         openldap_server_enable_ssl: false
-       
+        openldap_server_dn: dc=example,dc=com
+
 2) Configure an OpenLDAP server with SSL:
 
     - hosts: all
@@ -49,6 +50,7 @@ Examples
         openldap_server_state: Oregon
         openldap_server_location: Portland
         openldap_server_organization: IT
+        openldap_server_dn: dc=example,dc=com
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 #The domain prefix for ldap
 openldap_server_domain_name: example.com
 
-#This is the password for admin for openldap 
+#This is the password for admin for openldap
 openldap_server_rootpw: passme
 
 #The self signed ssl parameters
@@ -13,3 +13,5 @@ openldap_server_location: portland
 openldap_server_organization: IT
 
 openldap_server_enable_ssl: true
+
+openldap_server_dn: "dc={{ openldap_server_domain_name.split('.') | join(',dc=') }}"

--- a/tasks/configure_ldap.yml
+++ b/tasks/configure_ldap.yml
@@ -7,41 +7,41 @@
   file: path={{ openldap_server_app_path }}/certs/ state=directory owner={{ openldap_server_user }} group={{ openldap_server_user }}
 
 - name: Generate the private key for certificate request
-  shell: openssl genrsa -des3 -passout pass:password -out my1.key 1024 chdir={{ openldap_server_app_path }}/certs/ 
+  shell: openssl genrsa -des3 -passout pass:password -out my1.key 1024 chdir={{ openldap_server_app_path }}/certs/
          creates={{ openldap_server_app_path }}/certs/my1.key
 
-- name: Strip the passphrase from the key 
-  shell: openssl rsa -in my1.key -passin pass:password -out my.key chdir={{ openldap_server_app_path }}/certs/ 
+- name: Strip the passphrase from the key
+  shell: openssl rsa -in my1.key -passin pass:password -out my.key chdir={{ openldap_server_app_path }}/certs/
          creates={{ openldap_server_app_path }}/certs/my.key
 
-- name: Create and sign the the new certificate 
+- name: Create and sign the the new certificate
   shell: openssl req -new -x509 -subj '/C={{ openldap_server_country }}/ST={{ openldap_server_state }}/L={{ openldap_server_location }}/O={{ openldap_server_organization }}/CN={{ ansible_hostname }}/' -days 3650 -key my.key -out cert.crt -extensions v3_ca chdir={{ openldap_server_app_path }}/certs/   creates={{ openldap_server_app_path }}/certs/cert.crt
 
 - name: copy the supporting files
   copy: src=ldap dest=/etc/sysconfig/ldap mode=0755
   when: openldap_server_enable_ssl and ansible_os_family == 'RedHat'
-  notify: 
+  notify:
    - restart slapd
 
 
 - name: copy the supporting files
   copy: src=slapd_fedora dest=/etc/sysconfig/slapd mode=0755
   when: openldap_server_enable_ssl and ansible_distribution == "Fedora"
-  notify: 
+  notify:
    - restart slapd
 
 - name: copy the supporting files
   copy: src=slapd dest=/etc/default/slapd mode=0755
   when: openldap_server_enable_ssl and ansible_os_family == 'Debian'
-  notify: 
+  notify:
    - restart slapd
 
 - name: start the slapd service
-  service: name=slapd state=started enabled=yes 
+  service: name=slapd state=started enabled=yes
 
 - name: Copy the template for creating base dn
   template: src=domain.ldif dest=/tmp
 
 - name: add the base domain
-  shell: ldapadd -x -D "cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}" -w {{ openldap_server_rootpw }} -f /tmp/domain.ldif && touch {{ openldap_server_app_path }}/rootdn_created creates={{ openldap_server_app_path }}/rootdn_created
-   
+  shell: ldapadd -x -D "cn=Manager,{{ openldap_server_dn }}" -w {{ openldap_server_rootpw }} -f /tmp/domain.ldif && touch {{ openldap_server_app_path }}/rootdn_created creates={{ openldap_server_app_path }}/rootdn_created
+

--- a/tasks/install_ldap.yml
+++ b/tasks/install_ldap.yml
@@ -19,21 +19,21 @@
   file: path={{ openldap_server_app_path }}/slapd.d state=absent
 
 - name: Generate the root password for ldap
-  shell: slappasswd -s {{ openldap_server_rootpw }} 
+  shell: slappasswd -s {{ openldap_server_rootpw }}
   register: root_password
 
 - name: Copy the slapd.conf configuration file for Redhat
-  template: src=slapd.conf.j2 dest={{ openldap_server_app_path }}/slapd.conf
+  template: src=slapd.conf.j2 dest={{ openldap_server_app_path }}/slapd.conf owner={{ openldap_server_user }}
   when: ansible_os_family == "RedHat"
-  notify: 
+  notify:
    - restart slapd
 
 - name: Copy the slapd.conf configuration file
-  template: src=slapd.conf_ubuntu.j2 dest={{ openldap_server_app_path }}/slapd.conf
+  template: src=slapd.conf_ubuntu.j2 dest={{ openldap_server_app_path }}/slapd.conf owner={{ openldap_server_user }}
   when: ansible_os_family == "Debian"
-  notify: 
+  notify:
    - restart slapd
 
 - name: Copy the ldap.conf configuration file
-  template: src=ldap.conf.j2 dest={{ openldap_server_app_path }}/ldap.conf
+  template: src=ldap.conf.j2 dest={{ openldap_server_app_path }}/ldap.conf owner={{ openldap_server_user }}
 

--- a/templates/domain.ldif
+++ b/templates/domain.ldif
@@ -1,4 +1,3 @@
-dn: dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}
+dn: {{ openldap_server_dn }}
 objectClass: domain
-dc: {{ openldap_server_domain_name.split('.')[0] }}
-
+dc: {{ openldap_server_dn.split(',')[0].split('=')[1] }}

--- a/templates/ldap.conf.j2
+++ b/templates/ldap.conf.j2
@@ -5,7 +5,7 @@
 # See ldap.conf(5) for details
 # This file should be world readable but not world writable.
 
-BASE    dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}
+BASE    {{ openldap_server_dn }}
 {% if openldap_server_enable_ssl %}
 URI     ldaps://localhost
 TLS_REQCERT never

--- a/templates/slapd.conf.j2
+++ b/templates/slapd.conf.j2
@@ -8,21 +8,22 @@ modulepath      /usr/lib64/openldap
 
 access to *
                 by self write
-                by dn.base="cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}" write
+                by dn.base="cn=Manager,{{ openldap_server_dn }}" write
                 by * read
 access to attrs=userPassword
                 by self write
                 by anonymous auth
-                by dn.base="cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}" write
+                by dn.base="cn=Manager,{{ openldap_server_dn }}" write
                 by * none
 access to attrs=shadowLastChange
                 by self write
                 by * read
 
 database        bdb
-suffix          "dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}"
-rootdn          "cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}"
+suffix          "{{ openldap_server_dn}}"
+rootdn          "cn=Manager,{{ openldap_server_dn }}"
 rootpw          {{ root_password.stdout }}
+loglevel acl stats
 #This directory has to be created and would contain the ldap database.
 directory       /var/lib/ldap/{{ openldap_server_domain_name }}/
 index objectClass                       eq,pres

--- a/templates/slapd.conf_ubuntu.j2
+++ b/templates/slapd.conf_ubuntu.j2
@@ -14,20 +14,20 @@ moduleload      back_bdb.la
 
 access to *
                 by self write
-                by dn.base="cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}" write
+                by dn.base="cn=Manager,{{ openldap_server_dn }}" write
                 by * read
 access to attrs=userPassword
                 by self write
                 by anonymous auth
-                by dn.base="cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}" write
+                by dn.base="cn=Manager,{{ openldap_server_dn }}" write
                 by * none
 access to attrs=shadowLastChange
                 by self write
                 by * read
 
 database        bdb
-suffix          "dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}"
-rootdn          "cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}"
+suffix          "{{ openldap_server_dn }}"
+rootdn          "cn=Manager,{{ openldap_server_dn }}"
 rootpw          {{ root_password.stdout }}
 #This directory has to be created and would contain the ldap database.
 directory       /var/lib/ldap/{{ openldap_server_domain_name }}/


### PR DESCRIPTION
Without this, and when run with sudo, ansible will set the owner to the
non-root sudo account, which will cause permission denial for the slapd
process.
