### PR TITLE
Fix error for install debian 6&7

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,6 +19,9 @@ galaxy_info:
       - quantal
       - raring
       - saucy
+   - name: Debian
+      - squeeze
+      - wheezy
   categories:
    - system
 dependencies: []

--- a/tasks/install_ldap.yml
+++ b/tasks/install_ldap.yml
@@ -19,21 +19,21 @@
   file: path={{ openldap_server_app_path }}/slapd.d state=absent
 
 - name: Generate the root password for ldap
-  shell: slappasswd -s {{ openldap_server_rootpw }} 
+  shell: slappasswd -s {{ openldap_server_rootpw }}
   register: root_password
 
 - name: Copy the slapd.conf configuration file for Redhat
   template: src=slapd.conf.j2 dest={{ openldap_server_app_path }}/slapd.conf
   when: ansible_os_family == "RedHat"
-  notify: 
+  notify:
    - restart slapd
 
 - name: Copy the slapd.conf configuration file
-  template: src=slapd.conf_ubuntu.j2 dest={{ openldap_server_app_path }}/slapd.conf
+template: src=slapd.conf_ubuntu.j2 dest={{ openldap_server_app_path }}/slapd.conf owner={{ openldap_server_user }} group={{ openldap_server_user }} mode=0644
   when: ansible_os_family == "Debian"
-  notify: 
+  notify:
    - restart slapd
 
 - name: Copy the ldap.conf configuration file
-  template: src=ldap.conf.j2 dest={{ openldap_server_app_path }}/ldap.conf
+  template: src=ldap.conf.j2 dest={{ openldap_server_app_path }}/ldap.conf owner={{ openldap_server_user }} group={{ openldap_server_user }} mode=0644
 


### PR DESCRIPTION
Error ansible: stderr: ldap_bind: Invalid credentials (49)
Error log: could not open config file "/etc/ldap/slapd.conf": Permission denied (13)

Adding file permissions ldap.conf and slapd.conf.
And I agree running on debian 6 & 7.
