### PR TITLE
Properly split the domain name to support more than two levels of domain component (dc)

### DIFF
--- a/tasks/configure_ldap.yml
+++ b/tasks/configure_ldap.yml
@@ -44,4 +44,4 @@
   register: result
 
 - name: add the base domain
-  shell: ldapadd -x -D "cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}" -w {{ openldap_server_rootpw }} -f {{ result.dest }} && touch {{ openldap_server_app_path }}/rootdn_created creates={{ openldap_server_app_path }}/rootdn_created 
+  shell: ldapadd -x -D "cn=Manager,{{ domain_component }}" -w {{ openldap_server_rootpw }} -f {{ result.dest }} && touch {{ openldap_server_app_path }}/rootdn_created creates={{ openldap_server_app_path }}/rootdn_created

--- a/templates/domain.ldif
+++ b/templates/domain.ldif
@@ -1,4 +1,4 @@
-dn: dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}
+dn: {{ domain_component }}
 objectClass: domain
 dc: {{ openldap_server_domain_name.split('.')[0] }}
 

--- a/templates/ldap.conf.j2
+++ b/templates/ldap.conf.j2
@@ -5,7 +5,7 @@
 # See ldap.conf(5) for details
 # This file should be world readable but not world writable.
 
-BASE    dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}
+BASE    {{ domain_component }}
 {% if openldap_server_enable_ssl %}
 URI     ldaps://localhost
 TLS_REQCERT never

--- a/templates/slapd.conf.j2
+++ b/templates/slapd.conf.j2
@@ -8,20 +8,20 @@ modulepath      /usr/lib64/openldap
 
 access to *
                 by self write
-                by dn.base="cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}" write
+                by dn.base="cn=Manager,{{ domain_component }}" write
                 by * read
 access to attrs=userPassword
                 by self write
                 by anonymous auth
-                by dn.base="cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}" write
+                by dn.base="cn=Manager,{{ domain_component }}" write
                 by * none
 access to attrs=shadowLastChange
                 by self write
                 by * read
 
 database        bdb
-suffix          "dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}"
-rootdn          "cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}"
+suffix          "{{domain_component}}"
+rootdn          "cn=Manager,{{domain_component}}"
 rootpw          {{ root_password.stdout }}
 #This directory has to be created and would contain the ldap database.
 directory       /var/lib/ldap/{{ openldap_server_domain_name }}/

--- a/templates/slapd.conf_ubuntu.j2
+++ b/templates/slapd.conf_ubuntu.j2
@@ -14,20 +14,20 @@ moduleload      back_bdb.la
 
 access to *
                 by self write
-                by dn.base="cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}" write
+                by dn.base="cn=Manager,{{domain_component}}" write
                 by * read
 access to attrs=userPassword
                 by self write
                 by anonymous auth
-                by dn.base="cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}" write
+                by dn.base="cn=Manager,{{domain_component}}" write
                 by * none
 access to attrs=shadowLastChange
                 by self write
                 by * read
 
 database        bdb
-suffix          "dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}"
-rootdn          "cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}"
+suffix          "{{domain_component}}"
+rootdn          "cn=Manager,{{domain_component}}"
 rootpw          {{ root_password.stdout }}
 #This directory has to be created and would contain the ldap database.
 directory       /var/lib/ldap/{{ openldap_server_domain_name }}/

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,4 @@
 ---
-
+domain_component: "dc={{ openldap_server_domain_name.split('.') | join(',dc=') }}"
 env:
  RUNLEVEL: 1


### PR DESCRIPTION
The current code only splits the last two domain levels in the variable *openldap_server_domain_name*.
So if you have: *subdomain.example.com*, the domain component string will be: *dc=subdomain, dc=example*

The fix will split the whole *openldap_server_domain_name* and have a domain component for each level.

Real life example will be in countries which use a second level domain. eg ecetera.com.au will now be properly parsed as dc=ecetera,dc=com,dc=au
