### PR TITLE
ldaps is deprecated, starttls uses default port 389

### DIFF
--- a/files/ldap
+++ b/files/ldap
@@ -5,7 +5,7 @@
 #
 # Run slapd with -h "... ldap:/// ..."
 #   yes/no, default: yes
-SLAPD_LDAP=no
+SLAPD_LDAP=yes
 
 # Run slapd with -h "... ldapi:/// ..."
 #   yes/no, default: yes
@@ -13,7 +13,7 @@ SLAPD_LDAPI=yes
 
 # Run slapd with -h "... ldaps:/// ..."
 #   yes/no, default: no
-SLAPD_LDAPS=yes
+SLAPD_LDAPS=no
 
 # Run slapd with -h "... $SLAPD_URLS ..."
 # This option could be used instead of previous three ones, but:

--- a/files/slapd
+++ b/files/slapd
@@ -21,7 +21,7 @@ SLAPD_PIDFILE=
 # sockets.
 # Example usage:
 # SLAPD_SERVICES="ldap://127.0.0.1:389/ ldaps:/// ldapi:///"
-SLAPD_SERVICES="ldaps:/// ldapi:///"
+SLAPD_SERVICES="ldapi:/// ldap:///"
 
 # If SLAPD_NO_START is set, the init script will not start or restart
 # slapd (but stop will still work).  Uncomment this if you are

--- a/files/slapd_fedora
+++ b/files/slapd_fedora
@@ -6,7 +6,7 @@
 #   (use SASL with EXTERNAL mechanism for authentication)
 # - default: ldapi:/// ldap:///
 # - example: ldapi:/// ldap://127.0.0.1/ ldap://10.0.0.1:1389/ ldaps:///
-SLAPD_URLS="ldapi:/// ldaps:///"
+SLAPD_URLS="ldapi:/// ldap:///"
 
 # Any custom options
 #SLAPD_OPTIONS=""


### PR DESCRIPTION
Hello,

I changed some settings for ssl, as you configure the server with ldaps for port 636, which is deprecated.
Its better to use starttls, which uses the default port 389.