### PR TITLE
Fix template bug and conditionally call ldapadd

### DIFF
--- a/tasks/configure_ldap.yml
+++ b/tasks/configure_ldap.yml
@@ -40,8 +40,8 @@
   service: name=slapd state=started enabled=yes 
   
 - name: Copy the template for creating base dn
-  template: src={{ openldap_server_ldif }} dest=/tmp
+  template: src={{ openldap_server_ldif }} dest=/tmp/
   register: result
 
 - name: add the base domain
-  shell: ldapadd -x -D "cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}" -w {{ openldap_server_rootpw }} -f {{ result.dest }} && touch {{ openldap_server_app_path }}/rootdn_created creates={{ openldap_server_app_path }}/rootdn_created 
+  shell: ldapadd -x -D "cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}" -w {{ openldap_server_rootpw }} -f {{ result.dest|default(result.path) }} && touch {{ openldap_server_app_path }}/rootdn_created creates={{ openldap_server_app_path }}/rootdn_created 


### PR DESCRIPTION
This change works around [ansible #10300 issue](https://github.com/ansible/ansible/issues/10300).

In addition, when the LDIF `template` already exists on the remote system, the `ldapadd` command will fail because `result.dest` is not defined.  This PR addresses that issue by referencing `result.path` when `result.dest` is not defined.  This matches the JSON return value from the `template` module.