### PR TITLE
Replace deprecated use of bare variables.

### DIFF
--- a/tasks/install_ldap.yml
+++ b/tasks/install_ldap.yml
@@ -5,14 +5,14 @@
 
 - name: Install the openldap and required Packages for RedHat
   yum: name={{ item }} state=installed
-  with_items: openldap_server_pkgs
+  with_items: "{{ openldap_server_pkgs }}"
   when: ansible_os_family == 'RedHat'
 
 
 - name: Install the openldap and required Packages for Ubuntu
   apt: name={{ item }} state=installed update_cache=yes
-  with_items: openldap_server_pkgs
-  environment: env
+  with_items: "{{ openldap_server_pkgs }}"
+  environment: "{{ env }}"
   when: ansible_os_family == 'Debian'
 
 - name: Delete the configuration directory


### PR DESCRIPTION
Hello Benno,

this fixes the following deprecation warning and error:

    [DEPRECATION WARNING]: Using bare variables is deprecated.  This feature will be
    removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
    failed: [pacs] (item=[u'openldap_server_pkgs']) => {"failed": true, "item": ["openldap_server_pkgs"], "msg": "No package matching 'openldap_server_pkgs' is available"}

I've tested with Ansible v2.2.0.0.

Happy holidays :-)