### PR TITLE
Fix /  deprecated ansible syntax on install ldap file

### DIFF
--- a/tasks/configure_ldap.yml
+++ b/tasks/configure_ldap.yml
@@ -1,21 +1,21 @@
 ---
 
 - name: Create the directory for ldap database
-  file: path=/var/lib/ldap/{{ openldap_server_domain_name }}/ state=directory owner={{ openldap_server_user }} group={{ openldap_server_user }}
+  file: path=/var/lib/ldap/"{{ openldap_server_domain_name }}"/ state=directory owner="{{ openldap_server_user }}" group="{{ openldap_server_user }}"
 
 - name: Create the directory for ldap certificates
-  file: path={{ openldap_server_app_path }}/certs/ state=directory owner={{ openldap_server_user }} group={{ openldap_server_user }}
+  file: path="{{ openldap_server_app_path }}"/certs/ state=directory owner="{{ openldap_server_user }}" group="{{ openldap_server_user }}"
 
 - name: Generate the private key for certificate request
-  shell: openssl genrsa -des3 -passout pass:password -out my1.key 1024 chdir={{ openldap_server_app_path }}/certs/ 
-         creates={{ openldap_server_app_path }}/certs/my1.key
+  shell: openssl genrsa -des3 -passout pass:password -out my1.key 1024 chdir="{{ openldap_server_app_path }}"/certs/ 
+         creates="{{ openldap_server_app_path }}"/certs/my1.key
 
 - name: Strip the passphrase from the key 
-  shell: openssl rsa -in my1.key -passin pass:password -out my.key chdir={{ openldap_server_app_path }}/certs/ 
-         creates={{ openldap_server_app_path }}/certs/my.key
+  shell: openssl rsa -in my1.key -passin pass:password -out my.key chdir="{{ openldap_server_app_path }}"/certs/ 
+         creates="{{ openldap_server_app_path }}"/certs/my.key
 
 - name: Create and sign the the new certificate 
-  shell: openssl req -new -x509 -subj '/C={{ openldap_server_country }}/ST={{ openldap_server_state }}/L={{ openldap_server_location }}/O={{ openldap_server_organization }}/CN={{ ansible_hostname }}/' -days 3650 -key my.key -out cert.crt -extensions v3_ca chdir={{ openldap_server_app_path }}/certs/   creates={{ openldap_server_app_path }}/certs/cert.crt
+  shell: openssl req -new -x509 -subj '/C="{{ openldap_server_country }}"/ST="{{ openldap_server_state }}"/L="{{ openldap_server_location }}"/O="{{ openldap_server_organization }}"/CN="{{ ansible_hostname }}"/' -days 3650 -key my.key -out cert.crt -extensions v3_ca chdir="{{ openldap_server_app_path }}"/certs/   creates="{{ openldap_server_app_path }}"/certs/cert.crt
 
 - name: copy the supporting files
   copy: src=ldap dest=/etc/sysconfig/ldap mode=0755
@@ -40,8 +40,8 @@
   service: name=slapd state=started enabled=yes 
   
 - name: Copy the template for creating base dn
-  template: src={{ openldap_server_ldif }} dest=/tmp/
+  template: src="{{ openldap_server_ldif }}" dest=/tmp/
   register: result
 
 - name: add the base domain
-  shell: ldapadd -x -D "cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}" -w {{ openldap_server_rootpw }} -f {{ result.dest|default(result.path) }} && touch {{ openldap_server_app_path }}/rootdn_created creates={{ openldap_server_app_path }}/rootdn_created 
+  shell: ldapadd -x -D "cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}" -w "{{ openldap_server_rootpw }}" -f "{{ result.dest|default(result.path) }}" && touch "{{ openldap_server_app_path }}"/rootdn_created creates="{{ openldap_server_app_path }}"/rootdn_created 

--- a/tasks/configure_ldap.yml
+++ b/tasks/configure_ldap.yml
@@ -1,21 +1,21 @@
 ---
 
 - name: Create the directory for ldap database
-  file: path=/var/lib/ldap/"{{ openldap_server_domain_name }}"/ state=directory owner="{{ openldap_server_user }}" group="{{ openldap_server_user }}"
+  file: path=/var/lib/ldap/{{ openldap_server_domain_name }}/ state=directory owner={{ openldap_server_user }} group={{ openldap_server_user }}
 
 - name: Create the directory for ldap certificates
-  file: path="{{ openldap_server_app_path }}"/certs/ state=directory owner="{{ openldap_server_user }}" group="{{ openldap_server_user }}"
+  file: path={{ openldap_server_app_path }}/certs/ state=directory owner={{ openldap_server_user }} group={{ openldap_server_user }}
 
 - name: Generate the private key for certificate request
-  shell: openssl genrsa -des3 -passout pass:password -out my1.key 1024 chdir="{{ openldap_server_app_path }}"/certs/ 
-         creates="{{ openldap_server_app_path }}"/certs/my1.key
+  shell: openssl genrsa -des3 -passout pass:password -out my1.key 1024 chdir={{ openldap_server_app_path }}/certs/ 
+         creates={{ openldap_server_app_path }}/certs/my1.key
 
 - name: Strip the passphrase from the key 
-  shell: openssl rsa -in my1.key -passin pass:password -out my.key chdir="{{ openldap_server_app_path }}"/certs/ 
-         creates="{{ openldap_server_app_path }}"/certs/my.key
+  shell: openssl rsa -in my1.key -passin pass:password -out my.key chdir={{ openldap_server_app_path }}/certs/ 
+         creates={{ openldap_server_app_path }}/certs/my.key
 
 - name: Create and sign the the new certificate 
-  shell: openssl req -new -x509 -subj '/C="{{ openldap_server_country }}"/ST="{{ openldap_server_state }}"/L="{{ openldap_server_location }}"/O="{{ openldap_server_organization }}"/CN="{{ ansible_hostname }}"/' -days 3650 -key my.key -out cert.crt -extensions v3_ca chdir="{{ openldap_server_app_path }}"/certs/   creates="{{ openldap_server_app_path }}"/certs/cert.crt
+  shell: openssl req -new -x509 -subj '/C={{ openldap_server_country }}/ST={{ openldap_server_state }}/L={{ openldap_server_location }}/O={{ openldap_server_organization }}/CN={{ ansible_hostname }}/' -days 3650 -key my.key -out cert.crt -extensions v3_ca chdir={{ openldap_server_app_path }}/certs/   creates={{ openldap_server_app_path }}/certs/cert.crt
 
 - name: copy the supporting files
   copy: src=ldap dest=/etc/sysconfig/ldap mode=0755
@@ -44,4 +44,4 @@
   register: result
 
 - name: add the base domain
-  shell: ldapadd -x -D "cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}" -w "{{ openldap_server_rootpw }}" -f "{{ result.dest|default(result.path) }}" && touch "{{ openldap_server_app_path }}"/rootdn_created creates="{{ openldap_server_app_path }}"/rootdn_created 
+  shell: ldapadd -x -D "cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}" -w {{ openldap_server_rootpw }} -f {{ result.dest|default(result.path) }} && touch {{ openldap_server_app_path }}/rootdn_created creates={{ openldap_server_app_path }}/rootdn_created 

--- a/tasks/configure_ldap.yml
+++ b/tasks/configure_ldap.yml
@@ -40,7 +40,7 @@
   service: name=slapd state=started enabled=yes 
   
 - name: Copy the template for creating base dn
-  template: src="{{ openldap_server_ldif }}" dest=/tmp/
+  template: src={{ openldap_server_ldif }} dest=/tmp/
   register: result
 
 - name: add the base domain

--- a/tasks/install_ldap.yml
+++ b/tasks/install_ldap.yml
@@ -4,36 +4,36 @@
   include_vars: "{{ ansible_os_family }}.yml"
 
 - name: Install the openldap and required Packages for RedHat
-  yum: name={{ item }} state=preset
+  yum: name="{{ item }}" state=present
   with_items: "{{ openldap_server_pkgs }}"
   when: ansible_os_family == 'RedHat'
 
 
 - name: Install the openldap and required Packages for Ubuntu
-  apt: name={{ item }} state=preset update_cache=yes
+  apt: name="{{ item }}" state=present update_cache=yes
   with_items: "{{ openldap_server_pkgs }}"
   environment: env
   when: ansible_os_family == 'Debian'
 
 - name: Delete the configuration directory
-  file: path={{ openldap_server_app_path }}/slapd.d state=absent
+  file: path="{{ openldap_server_app_path }}"/slapd.d state=absent
 
 - name: Generate the root password for ldap
-  shell: slappasswd -s {{ openldap_server_rootpw }} 
+  shell: slappasswd -s "{{ openldap_server_rootpw }}" 
   register: root_password
 
 - name: Copy the slapd.conf configuration file for Redhat
-  template: src=slapd.conf.j2 dest={{ openldap_server_app_path }}/slapd.conf
+  template: src=slapd.conf.j2 dest="{{ openldap_server_app_path }}"/slapd.conf
   when: ansible_os_family == "RedHat"
   notify: 
    - restart slapd
 
 - name: Copy the slapd.conf configuration file
-  template: src=slapd.conf_ubuntu.j2 dest={{ openldap_server_app_path }}/slapd.conf
+  template: src=slapd.conf_ubuntu.j2 dest="{{ openldap_server_app_path }}"/slapd.conf
   when: ansible_os_family == "Debian"
   notify: 
    - restart slapd
 
 - name: Copy the ldap.conf configuration file
-  template: src=ldap.conf.j2 dest={{ openldap_server_app_path }}/ldap.conf
+  template: src=ldap.conf.j2 dest="{{ openldap_server_app_path }}"/ldap.conf
 

--- a/tasks/install_ldap.yml
+++ b/tasks/install_ldap.yml
@@ -19,7 +19,7 @@
   file: path="{{ openldap_server_app_path }}"/slapd.d state=absent
 
 - name: Generate the root password for ldap
-  shell: slappasswd -s "{{ openldap_server_rootpw }}" 
+  shell: slappasswd -s {{ openldap_server_rootpw }}
   register: root_password
 
 - name: Copy the slapd.conf configuration file for Redhat

--- a/tasks/install_ldap.yml
+++ b/tasks/install_ldap.yml
@@ -4,14 +4,14 @@
   include_vars: "{{ ansible_os_family }}.yml"
 
 - name: Install the openldap and required Packages for RedHat
-  yum: name={{ item }} state=installed
-  with_items: openldap_server_pkgs
+  yum: name={{ item }} state=preset
+  with_items: "{{ openldap_server_pkgs }}"
   when: ansible_os_family == 'RedHat'
 
 
 - name: Install the openldap and required Packages for Ubuntu
-  apt: name={{ item }} state=installed update_cache=yes
-  with_items: openldap_server_pkgs
+  apt: name={{ item }} state=preset update_cache=yes
+  with_items: "{{ openldap_server_pkgs }}"
   environment: env
   when: ansible_os_family == 'Debian'
 

--- a/tasks/install_ldap.yml
+++ b/tasks/install_ldap.yml
@@ -23,17 +23,17 @@
   register: root_password
 
 - name: Copy the slapd.conf configuration file for Redhat
-  template: src=slapd.conf.j2 dest="{{ openldap_server_app_path }}"/slapd.conf
+  template: src=slapd.conf.j2 dest={{ openldap_server_app_path }}/slapd.conf
   when: ansible_os_family == "RedHat"
   notify: 
    - restart slapd
 
 - name: Copy the slapd.conf configuration file
-  template: src=slapd.conf_ubuntu.j2 dest="{{ openldap_server_app_path }}"/slapd.conf
+  template: src=slapd.conf_ubuntu.j2 dest={{ openldap_server_app_path }}/slapd.conf
   when: ansible_os_family == "Debian"
   notify: 
    - restart slapd
 
 - name: Copy the ldap.conf configuration file
-  template: src=ldap.conf.j2 dest="{{ openldap_server_app_path }}"/ldap.conf
+  template: src=ldap.conf.j2 dest={{ openldap_server_app_path }}/ldap.conf
 

--- a/templates/domain.ldif
+++ b/templates/domain.ldif
@@ -1,4 +1,4 @@
-dn: dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}
+dn: dc="{{ openldap_server_domain_name.split('.')[0] }}",dc="{{ openldap_server_domain_name.split('.')[1] }}"
 objectClass: domain
-dc: {{ openldap_server_domain_name.split('.')[0] }}
+dc: "{{ openldap_server_domain_name.split('.')[0] }}"
 

--- a/templates/domain.ldif
+++ b/templates/domain.ldif
@@ -1,4 +1,3 @@
-dn: dc="{{ openldap_server_domain_name.split('.')[0] }}",dc="{{ openldap_server_domain_name.split('.')[1] }}"
+dn: dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}
 objectClass: domain
-dc: "{{ openldap_server_domain_name.split('.')[0] }}"
-
+dc: {{ openldap_server_domain_name.split('.')[0] }}

--- a/templates/ldap.conf.j2
+++ b/templates/ldap.conf.j2
@@ -5,7 +5,7 @@
 # See ldap.conf(5) for details
 # This file should be world readable but not world writable.
 
-BASE    dc="{{ openldap_server_domain_name.split('.')[0] }}",dc="{{ openldap_server_domain_name.split('.')[1] }}"
+BASE    dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}
 {% if openldap_server_enable_ssl %}
 URI     ldaps://localhost
 TLS_REQCERT never

--- a/templates/ldap.conf.j2
+++ b/templates/ldap.conf.j2
@@ -5,7 +5,7 @@
 # See ldap.conf(5) for details
 # This file should be world readable but not world writable.
 
-BASE    dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}
+BASE    dc="{{ openldap_server_domain_name.split('.')[0] }}",dc="{{ openldap_server_domain_name.split('.')[1] }}"
 {% if openldap_server_enable_ssl %}
 URI     ldaps://localhost
 TLS_REQCERT never

--- a/templates/slapd.conf.j2
+++ b/templates/slapd.conf.j2
@@ -22,9 +22,9 @@ access to attrs=shadowLastChange
 database        bdb
 suffix          "dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}"
 rootdn          "cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}"
-rootpw          {{ root_password.stdout }}
+rootpw          "{{ root_password.stdout }}"
 #This directory has to be created and would contain the ldap database.
-directory       /var/lib/ldap/{{ openldap_server_domain_name }}/
+directory       /var/lib/ldap/"{{ openldap_server_domain_name }}"/
 index objectClass                       eq,pres
 index ou,cn,mail,surname,givenname      eq,pres,sub
 index uidNumber,gidNumber,loginShell    eq,pres

--- a/templates/slapd.conf.j2
+++ b/templates/slapd.conf.j2
@@ -22,9 +22,9 @@ access to attrs=shadowLastChange
 database        bdb
 suffix          "dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}"
 rootdn          "cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}"
-rootpw          "{{ root_password.stdout }}"
+rootpw          {{ root_password.stdout }}
 #This directory has to be created and would contain the ldap database.
-directory       /var/lib/ldap/"{{ openldap_server_domain_name }}"/
+directory       /var/lib/ldap/{{ openldap_server_domain_name }}/
 index objectClass                       eq,pres
 index ou,cn,mail,surname,givenname      eq,pres,sub
 index uidNumber,gidNumber,loginShell    eq,pres

--- a/templates/slapd.conf_ubuntu.j2
+++ b/templates/slapd.conf_ubuntu.j2
@@ -28,9 +28,9 @@ access to attrs=shadowLastChange
 database        bdb
 suffix          "dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}"
 rootdn          "cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}"
-rootpw          {{ root_password.stdout }}
+rootpw          "{{ root_password.stdout }}"
 #This directory has to be created and would contain the ldap database.
-directory       /var/lib/ldap/{{ openldap_server_domain_name }}/
+directory       /var/lib/ldap/"{{ openldap_server_domain_name }}"/
 index objectClass                       eq,pres
 index ou,cn,mail,surname,givenname      eq,pres,sub
 index uidNumber,gidNumber,loginShell    eq,pres

--- a/templates/slapd.conf_ubuntu.j2
+++ b/templates/slapd.conf_ubuntu.j2
@@ -28,9 +28,9 @@ access to attrs=shadowLastChange
 database        bdb
 suffix          "dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}"
 rootdn          "cn=Manager,dc={{ openldap_server_domain_name.split('.')[0] }},dc={{ openldap_server_domain_name.split('.')[1] }}"
-rootpw          "{{ root_password.stdout }}"
+rootpw          {{ root_password.stdout }}
 #This directory has to be created and would contain the ldap database.
-directory       /var/lib/ldap/"{{ openldap_server_domain_name }}"/
+directory       /var/lib/ldap/{{ openldap_server_domain_name }}/
 index objectClass                       eq,pres
 index ou,cn,mail,surname,givenname      eq,pres,sub
 index uidNumber,gidNumber,loginShell    eq,pres


### PR DESCRIPTION
Fix deprecated ansible syntax which are not compatible with Ubuntu >= 18.04:

- change `state=installed` to `state=present`
- `with_items` should use `"{{ ... }}"` 
- replace some `{{ . }}` to `"{{ .. }}"`